### PR TITLE
Add instruction and Dockerfile for docker user.

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,89 @@
+# FROM nvcr.io/nvidia/pytorch:21.09-py3
+# use 23.02 version which has cuda 12.0.1 with pytorch 1.14 in ubunut 20.4
+# see https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes
+FROM nvcr.io/nvidia/pytorch:23.02-py3
+
+ENV DEBIAN_FRONTEND=noninteractive 
+
+# dependencies for gym
+#
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+ libxcursor-dev \
+ libxrandr-dev \
+ libxinerama-dev \
+ libxi-dev \
+ mesa-common-dev \
+ zip \
+ unzip \
+ make \
+ gcc-8 \
+ g++-8 \
+ vulkan-utils \
+ mesa-vulkan-drivers \
+ pigz \
+ git \
+ libegl1 \
+ git-lfs \
+ sudo \
+ libosmesa6-dev \
+ xserver-xephyr \
+ && apt-get clean
+
+# Force gcc 8 to avoid CUDA 10 build issues on newer base OS
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 8
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 8
+
+# WAR for eglReleaseThread shutdown crash in libEGL_mesa.so.0 (ensure it's never detected/loaded)
+# Can't remove package libegl-mesa0 directly (because of libegl1 which we need)
+RUN rm /usr/lib/x86_64-linux-gnu/libEGL_mesa.so.0 /usr/lib/x86_64-linux-gnu/libEGL_mesa.so.0.0.0 /usr/share/glvnd/egl_vendor.d/50_mesa.json
+
+COPY docker/nvidia_icd.json /usr/share/vulkan/icd.d/nvidia_icd.json
+COPY docker/10_nvidia.json /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+
+WORKDIR /opt/isaacgym
+
+# Add non-root user and add it to non-password sudoers
+RUN useradd --create-home gymuser
+RUN adduser gymuser sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER gymuser
+
+# dependency do not conflict pytorch
+RUN pip install --upgrade pip &&  pip install --no-cache-dir gdown mujoco numpy-stl vtk patchelf termcolor scikit-image numpy  scipy ipdb 'joblib>=1.2.0' \
+ opencv-python==4.6.0.66 \
+ tqdm \
+ pyyaml \
+ wandb \
+ scikit-image \
+ gym \
+ git+https://github.com/ZhengyiLuo/smplx.git@master \
+ lxml \
+ human_body_prior \
+ autograd \
+ scikit-learn \
+ chumpy \
+ wandb \
+ pyvirtualdisplay \
+ chardet \
+ cchardet \
+ geoopt \ 
+ imageio-ffmpeg \
+ easydict \
+ open3d \
+ torchgeometry \
+ pytorch_lightning \
+ rl-games==1.1.4 
+    
+
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
+ENV PATH "$PATH:/home/gymuser/.local/bin"
+
+# copy gym repo to docker
+COPY --chown=gymuser . .
+
+# install gym modules
+ENV PATH="/home/gymuser/.local/bin:$PATH"
+RUN cd python && pip install -q -e .
+

--- a/docs/docker_instruction.MD
+++ b/docs/docker_instruction.MD
@@ -1,0 +1,43 @@
+## Quick steps for evaluating in Docker 
+
+1. Download isaacgym replace its Dockerfile in the `docker` with [ours](Dockerfile). 
+2. Build a image by running `build.sh`.
+3. Run the container by running `run.sh`. 
+4. Download the code from this repo by 
+```bash
+git clone https://github.com/ZhengyiLuo/PerpetualHumanoidControl
+```
+
+5. Download SMPL data, rename and put them in the PerpetualHumanoidControl folder
+```bash
+mv basicmodel_neutral_lbs_10_207_0_v1.1.0.pkl SMPL_NEUTRAL.pkl
+mv basicmodel_m_lbs_10_207_0_v1.1.0.pkl SMPL_MALE.pkl
+mv basicmodel_f_lbs_10_207_0_v1.1.0.pkl SMPLE_FEMALE.pkl
+```
+
+The file sturcture should be: 
+```
+PerpetualHumanoidControl/
+├── data
+│   └── smpl
+│       ├── SMPL_FEMALE.pkl
+│       ├── SMPL_MALE.pkl
+│       └── SMPL_NEUTRAL.pkl
+```
+
+6. Download the model files:
+```bash
+sh download.sh
+```
+
+7. Now we should be able to run the evaluation script!😄 
+```bash
+python phc/run.py --task HumanoidImMCPGetup --cfg_env phc/data/cfg/phc_shape_mcp_iccv.yaml --cfg_train phc/data/cfg/train/rlg/im_mcp.yaml --motion_file sample_data/amass_isaac_standing_upright_slim.pkl --network_path output/phc_shape_mcp_iccv --test --num_envs 1 --epoch -1
+```
+
+## Dockerfile explained 
+We have made several modifications to the official isaacgym Dockerfile.
+1. Use `nvcr.io/nvidia/pytorch:23.02-py3` as base image, which ships last version of `1.x` pytorch in nvidia's images. See support matrix [here](https://docs.nvidia.com/deeplearning/frameworks/pytorch-release-notes). 
+2. Add the gymuser to no-password sudoer. 
+3. Install `libosmesa6-dev` and `xserver-xephyr` for X11. 
+4. Install all python dependency this repo needed. 


### PR DESCRIPTION
Add docker instruction and corresponding Dockerfile needed to setup the docker environment as @ZhengyiLuo kindly suggested in https://github.com/ZhengyiLuo/PerpetualHumanoidControl/issues/4. 

However, I'm not sure which pytorch version is preferred, the [README.md](https://github.com/ZhengyiLuo/PerpetualHumanoidControl/blob/master/README.MD) suggests that we use CUDA11.6: 
```
conda install pytorch torchvision torchaudio pytorch-cuda=11.6 -c pytorch -c nvidia
```
which should be compatible with pytorch 1.13 as shown [here](https://pytorch.org/get-started/previous-versions/): 
```
conda install pytorch==1.13.1 torchvision==0.14.1 torchaudio==0.13.1 pytorch-cuda=11.6 -c pytorch -c nvidia
```

But the [requirements.txt](https://github.com/ZhengyiLuo/PerpetualHumanoidControl/blob/master/requirement.txt) suggests using the github version of `geoopt`, which [bumps](https://github.com/geoopt/geoopt/pull/217) to pytorch 2.0 about 5 months ago. 

@ZhengyiLuo Currently I'm sticking with the pip version of `geoopt`, which still uses pytorch 1.x. Feel free to contact me if pytorch 2.x is preferred. 😄 I'll update the base image and dependencies then. 